### PR TITLE
Fixing 2 issues regarding deletion of comments

### DIFF
--- a/src/comment.js
+++ b/src/comment.js
@@ -9,6 +9,8 @@ export default class Comment {
         this.y = 0;
         this.dragPosition = [0, 0];
         this.links = [];
+        
+        this.id = Comment.incrementId();
  
         this.el = document.createElement('div');
         this.el.tabIndex = 1;
@@ -18,6 +20,12 @@ export default class Comment {
     
         new Draggable(this.el, () => this.onStart(), (dx, dy) => this.onTranslate(dx, dy));
         this.update();
+    }
+    
+    static incrementId() {
+        if (!this.latestId) this.latestId = 1
+        else this.latestId++
+        return this.latestId
     }
 
     linkTo(ids) {

--- a/src/manager.js
+++ b/src/manager.js
@@ -44,7 +44,10 @@ export default class CommentManager {
 
     deleteComment(comment) {
         this.editor.view.area.removeChild(comment.el);
-        this.comments.splice(this.comments.indexOf(comment), 1);
+        
+        this.comments = this.comments.filter(function(c){
+          return c.id !== comment.id;
+        })
 
         this.editor.trigger('commentremoved', comment);
     }
@@ -61,7 +64,9 @@ export default class CommentManager {
     }
 
     fromJSON(list) {
-        this.comments.map(this.deleteComment);
+        this.comments.map(function(c){
+          return this.deleteComment(c);
+        }.bind(this));
         list.map(item => {
             if (item.type === 'frame') {
                 this.addFrameComment(item.text, item.position, item.links, item.width, item.height)


### PR DESCRIPTION
I was having two issues and the changes on this pull request fixed it for me:

1. When CommentManager.fromJson was calling deleteComment , 'this' was undefined. I fixed it by binding 'this' when calling fromJSON;

2. I'm not sure about the reason behind that but when iterating over CommentManager.comments and calling deleteComment on each of them, some were not being deleted. In fact, some of them were being removed from the comments list but not from the view. I fixed it by adding an unique id for each comment created and checking for that id before deleting.
