### PR TITLE
Fixed window event listener removal for Draggable on destroy

### DIFF
--- a/src/comment.js
+++ b/src/comment.js
@@ -21,7 +21,8 @@ export default class Comment {
         this.el.addEventListener('focus', this.onFocus.bind(this));
         this.el.addEventListener('blur', this.onBlur.bind(this));
     
-        new Draggable(this.el, () => this.onStart(), (dx, dy) => this.onTranslate(dx, dy));
+        this.draggable = new Draggable(
+            this.el, () => this.onStart(), (dx, dy) => this.onTranslate(dx, dy));
     }
 
     linkTo(ids) {
@@ -86,5 +87,9 @@ export default class Comment {
             position: [ this.x, this.y ],
             links: this.links
         }
+    }
+
+    destroy() {
+        this.draggable.destroy();
     }
 }

--- a/src/draggable.js
+++ b/src/draggable.js
@@ -13,8 +13,16 @@ export default class Draggable {
 
     initEvents(el) {
         el.addEventListener('pointerdown', this.down.bind(this));
-        window.addEventListener('pointermove', this.move.bind(this));
-        window.addEventListener('pointerup', this.up.bind(this));
+
+        const windowListenGuard = (type, listener) => {
+            window.addEventListener(type, listener);
+            return () => window.removeEventListener(type, listener);
+        };
+
+        this.onDestroy = [
+            windowListenGuard('pointermove', this.move.bind(this)),
+            windowListenGuard('pointerup', this.up.bind(this))
+        ];
     }
 
     getCoords(e) {
@@ -48,5 +56,9 @@ export default class Draggable {
         }
 
         this.mouseStart = null;
+    }
+
+    destroy() {
+        this.onDestroy.forEach(cb => cb());
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -123,6 +123,8 @@ function install(editor, { margin = 30, disableBuiltInEdit = false }) {
     if (editor.exist('clear')) { // compatibility with previous versions
         editor.on('clear', () => manager.deleteComments())
     }
+
+    editor.on('destroy', () => manager.destroy());
 }
 
 export default {

--- a/src/manager.js
+++ b/src/manager.js
@@ -74,4 +74,8 @@ export default class CommentManager {
             }
         });
     }
+
+    destroy() {
+        this.comments.forEach(comment => comment.destroy());
+    }
 }

--- a/src/manager.js
+++ b/src/manager.js
@@ -45,6 +45,7 @@ export default class CommentManager {
     deleteComment(comment) {
         this.editor.view.area.removeChild(comment.el);
         this.comments.splice(this.comments.indexOf(comment), 1);
+        comment.destroy();
 
         this.editor.trigger('commentremoved', comment);
     }


### PR DESCRIPTION
Currently, for every comment, `Draggable` registers two event listeners on `window` and never removes them, including on `destroy`. As a result destroyed `NodeEditor`s that use the plugin stay referenced by `window` and don't get removed (including all their nodes, etc.).

This pull request fixes that by adding `Draggable.destroy` and makes sure it's called on `removecomment` and on `destroy` appropriately.