### PR TITLE
Fix: draggable comment was moving after rename prompt cancel or confirm

### DIFF
--- a/src/draggable.js
+++ b/src/draggable.js
@@ -25,9 +25,11 @@ export default class Draggable {
 
     down(e) {
         e.stopPropagation();
-        this.mouseStart = this.getCoords(e);
 
-        this.onStart();
+        if (e.which === 1) {
+            this.mouseStart = this.getCoords(e);
+            this.onStart();
+        }
     }
 
     move(e) {


### PR DESCRIPTION
Small issue. when you edit the comment name. after confirm or cancel, the Draggable is still moving.

So the code just make sure the draggable will start to track the position and update it only with the lef click of the mouse/pointer long press in touch case.

