### PR TITLE
feat: return created comment in add functions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,6 +179,7 @@ export class CommentPlugin<Schemes extends ExpectedSchemes, K = BaseArea<Schemes
    * @param text Comment text
    * @param position Comment position
    * @param link Node ID the comment is linked with
+   * @returns comment that was created
    */
   public addInline(text: string, [x, y]: [number, number], link?: string) {
     const comment = new InlineComment(text, this.area, {
@@ -195,6 +196,7 @@ export class CommentPlugin<Schemes extends ExpectedSchemes, K = BaseArea<Schemes
     if (link) comment.linkTo([link])
 
     this.add(comment)
+    return comment
   }
 
   /**
@@ -203,6 +205,7 @@ export class CommentPlugin<Schemes extends ExpectedSchemes, K = BaseArea<Schemes
    * When user drops a node on a comment, the node will be linked to the comment.
    * @param text Comment text
    * @param links List of node IDs the comment is linked with
+   * @returns comment that was created
    */
   public addFrame(text: string, links: string[] = []) {
     const comment = new FrameComment(text, this.area, this.editor, {
@@ -218,6 +221,7 @@ export class CommentPlugin<Schemes extends ExpectedSchemes, K = BaseArea<Schemes
 
     this.add(comment)
     this.area.area.content.reorder(comment.element, this.area.area.content.holder.firstChild)
+    return comment
   }
 
   public add(comment: Comment) {


### PR DESCRIPTION
### Description

* Added return statement to return the created comment in both comment creation helper functions

### Related Issues

<!-- If your pull request is related to any GitHub issue(s), mention them here. -->

### Checklist

<!-- Mark the items that apply to this pull request -->

- [ ] I have read and followed [the contribution guidelines](https://retejs.org/docs/contribution#contribution).
- [ ] I have [tested my changes](https://github.com/retejs/rete-qa) locally.
- [ ] I have updated [documentation](https://github.com/retejs/retejs.org) accordingly (if necessary).
- [ ] I have added unit and [E2E](https://github.com/retejs/rete-qa) tests (if applicable).

### Additional Notes

<!-- Any additional information or notes for the reviewers. -->
